### PR TITLE
remove $app/environment usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.6 - 2025-06-22
+
+- Removed `$app/enviroment` import from `T.svelte`, to make HDS usable in non-SvelteKit projects
+
 ## 1.1.5 - 2025-06-20
 
 - Fixed Button event on:click bug

--- a/src/lib/components/Internationalization/T.svelte
+++ b/src/lib/components/Internationalization/T.svelte
@@ -1,10 +1,7 @@
 <script lang="ts" generics="StringsT extends I18nStrings">
-	import { run } from 'svelte/legacy';
-
 	import { type ToDotPaths, type I18nStrings, type PrimitiveType } from './types.js';
 	import { getContext, onMount, tick, getAllContexts, type Component, hydrate } from 'svelte';
 	import { InternationalizationService } from './i18n.js';
-	import { browser } from '$app/environment';
 	import { getMessage as getMessageBase } from './t.js';
 
 	type ComponentDeclaration = {
@@ -152,10 +149,12 @@
 
 	let mounted = $state(false);
 
-	run(() => {
+	const isBrowser = typeof window !== 'undefined';
+
+	$effect(() => {
 		params;
 		key;
-		if (browser && mounted) {
+		if (isBrowser && mounted) {
 			renderFrontend();
 		}
 	});


### PR DESCRIPTION
HDS cannot be loaded in non-sveltekit project because of $app/environment fails. Updates to use a different method