### PR TITLE
Add copy button in code block

### DIFF
--- a/src/lib/components/CodeBlock/CodeBlock.svelte
+++ b/src/lib/components/CodeBlock/CodeBlock.svelte
@@ -1,29 +1,54 @@
 <script lang="ts">
 	//import './prism.scss';
 	import './hljs.scss';
+	import Button from '../Button/Button.svelte';
+	import IconCopy from '@hyvor/icons/IconCopy';
 
 	type InputLanguage = 'html' | 'css' | 'js' | 'ts' | 'yaml' | 'json' | 'svelte' | 'jsx' | 'php';
-
 	const languagesMap: Partial<Record<InputLanguage, Language>> = {
 		svelte: 'html',
 		jsx: 'js'
 	};
-
 	import getCode, { type Language } from './getCode.js';
+
 	interface Props {
 		code: string;
 		language?: InputLanguage | null;
 	}
 
 	let { code, language = 'html' }: Props = $props();
+	let languageCode = $derived(
+		language ? languagesMap[language] || language : null
+	) as Language | null;
 
-	let languageCode = $derived(language ? (languagesMap[language] || language) : null) as Language | null;
+	function copyToClipboard() {
+		navigator.clipboard.writeText(code);
+	}
 </script>
 
-<pre class="language-{languageCode} hljs"><code>{@html getCode(code, languageCode)}</code></pre>
+<div class="code-container">
+	<div class="copy-button">
+		<Button variant="fill" onclick={copyToClipboard}>
+			<IconCopy />
+		</Button>
+	</div>
+	<pre class="language-{languageCode} hljs"><code>{@html getCode(code, languageCode)}</code></pre>
+</div>
 
 <style>
 	/*styles for CodeBlock component */
+	.code-container {
+		position: relative;
+	}
+
+	.code-container .copy-button {
+		position: absolute;
+		top: 0px;
+		right: 12px;
+		transform: translateY(-40%);
+		z-index: 10;
+	}
+
 	pre {
 		text-align: left;
 		white-space: pre;
@@ -35,6 +60,7 @@
 		padding: 20px;
 		line-height: 1.2;
 	}
+
 	pre code {
 		all: unset;
 		font-family:

--- a/src/lib/components/CodeBlock/TabbedCodeBlock.svelte
+++ b/src/lib/components/CodeBlock/TabbedCodeBlock.svelte
@@ -1,78 +1,74 @@
 <script lang="ts">
-	import type { Snippet } from "svelte";
-	import Button from "../Button/Button.svelte";
+	import type { Snippet } from 'svelte';
+	import Button from '../Button/Button.svelte';
 
-    interface Props {
-        children: Snippet;
-        tabs: string[];
-    }
+	interface Props {
+		children: Snippet;
+		tabs: string[];
+	}
 
-    let { children, tabs }: Props = $props();
-    let activeTab = $state(tabs[0]);
+	let { children, tabs }: Props = $props();
+	let activeTab = $state(tabs[0]);
 
-    function activateTab(tab: string) {
-        activeTab = tab;
+	function activateTab(tab: string) {
+		activeTab = tab;
 
-        const pres = blocksEl.querySelectorAll("pre");
-        const tabIndex = tabs.indexOf(tab);
+		const pres = blocksEl.querySelectorAll<HTMLElement>('.code-container');
+		const tabIndex = tabs.indexOf(tab);
 
-        pres.forEach((pre, index) => {
-            if (index === tabIndex) {
-                pre.style.display = "block";
-            } else {
-                pre.style.display = "none";
-            }
-        });
-    }
+		pres.forEach((pre, index) => {
+			if (index === tabIndex) {
+				pre.style.display = 'block';
+			} else {
+				pre.style.display = 'none';
+			}
+		});
+	}
 
-    let blocksEl: HTMLDivElement;
+	let blocksEl: HTMLDivElement;
 </script>
 
 <div class="tabbed">
+	<div class="selectors">
+		{#each tabs as tab}
+			<Button
+				size="x-small"
+				color={activeTab === tab ? 'accent' : 'input'}
+				onclick={() => activateTab(tab)}>{tab}</Button
+			>
+		{/each}
+	</div>
 
-    <div class="selectors">
-        {#each tabs as tab}
-            <Button 
-                size="x-small" 
-                color={activeTab === tab ? 'accent' : 'input'}
-                onclick={() => activateTab(tab)}
-            >{tab}</Button>
-        {/each}
-    </div>
-
-    <div class="blocks" bind:this={blocksEl}>
-        {@render children()}
-    </div>
-
+	<div class="blocks" bind:this={blocksEl}>
+		{@render children()}
+	</div>
 </div>
 
 <style>
+	.tabbed {
+		margin: 1.5rem 0 1rem 0;
+		position: relative;
+	}
 
-    .tabbed {
-        margin: 1.5rem 0 1rem 0;
-        position: relative
-    }
+	.selectors {
+		display: inline-flex;
+		position: absolute;
+		top: 0;
+		left: 20px;
+		z-index: 1;
+		transform: translateY(-50%);
+		gap: 3px;
+	}
 
-    .selectors {
-        display: inline-flex;
-        position: absolute;
-        top: 0;
-        left: 20px;
-        z-index: 1;
-        transform: translateY(-50%);
-        gap: 3px;
-    }
+	.selectors > :global(button) {
+		border: 1px solid var(--border);
+	}
 
-    .selectors > :global(button) {
-        border: 1px solid var(--border);
-    }
+	.blocks > :global(.code-container:not(:first-child)) {
+		display: none;
+	}
 
-    .blocks > :global(pre:not(:first-child)) {
-        display: none;
-    }
-
-    .blocks > :global(pre) {
-        margin: 0
-    }
-
+	.blocks > :global(.code-container) {
+		margin: 0;
+	}
 </style>


### PR DESCRIPTION
Closes: #233 

updated `TabbedCodeBlock` to handle new `CodeBlock` structure

- [x] Add a "copy button" to the CodeBlock component
- [x] Use <IconCopy /> from `@hyvor/icons.
- [x] Use component for creating this button